### PR TITLE
Default to current time in GitHub action

### DIFF
--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -35,6 +35,9 @@ func main() {
 		githubactions.Infof("Overwriting vm.VDFName (out): %q", outFile)
 	}
 
+	// default to current time before override
+	vm.Timestamp = time.Now()
+
 	if tsOverrideStr != "" {
 		location := time.Local
 		if true /* *tsIsUtc */ {


### PR DESCRIPTION
While it works for the compiled executable, I noticed that without `-ts` override the GitHub Action defaults to the maximum timestamp (2039-01-01) instead of the current time.

I thought to help out with a PR here this time. But I have not compiled the changes, let alone tested them. Feel free to close this PR and commit this tiny change yourself (in a more suitable way). No need for an external contribution for this.