### PR TITLE
Ensure termination of truncated comment

### DIFF
--- a/vdf/writer.go
+++ b/vdf/writer.go
@@ -334,7 +334,7 @@ func vdfDateTime(t time.Time) time_t {
 }
 
 func comment(c string) Comment {
-	maxLen := int(unsafe.Sizeof(Comment{}))
+	maxLen := int(unsafe.Sizeof(Comment{}))-1 // Room for terminating null-character
 	if len(c) > maxLen {
 		c = c[:maxLen]
 	}


### PR DESCRIPTION
A small (almost cosmetic) thing I just noticed: The comment is truncated to exactly the allocated character length (255). For display purposes, however, the comment should be terminated with the character `0x1A`, i.e. the comment should be truncated to one character less (254).

Otherwise when reading the comment of an VDF, tools might keep reading indefinitely (at least until after the version information). This is visible in the viewer of GothicVDFS and might likely cause issues with tools that read VDFs in-game.

This PR simply truncates the comment to one character less (maximum length minus one), to ensure the termination of the comment.

---

PS: A small note: The recent release did not update the container-version in the `action.yml`, falling back to using v1.1.0 when running the action with `uses: kirides/vdfsbuilder@v1.2.0`.

On a related note, I've seen many GitHub actions stick to strict semantic versioning. In particular the [additional use of lightweight tags for major versions](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management), e.g. `v1`. These are then re-adjusted to always point to the latest minor release e.g. `v1` points to `v1.2.0`. That allows end-users of the action to keep `uses: kirides/vdfsbuilder@v1` without referencing specific commit hashes, or explicit minor versions. Ultimately, it avoids to having to change their workflow files for every non-breaking, minor release of the action.